### PR TITLE
Use a specific, named HTTP Client for communicating with the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.2.0 - 2020-06-10
+
+### Added
+
+- [#2](https://github.com/netglue/primo/pull/2) Adds `Primo\Http\PrismicHttpClient` interface. This interface is just aliased to the PSR Http Client interface but the Api client factory targets the new interface in the container so that it is easier to change the client used specifically for the Prismic API. Typically, you'd want to wrap the standard client in a caching client…
+
+### Changed
+
+- [#2](https://github.com/netglue/primo/pull/2) Adds some suggest items to composer.json
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#2](https://github.com/netglue/primo/pull/2) Corrects the config provider class name in composer.json
+
 ## 0.1.0 - 2020-06-08
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "laminas": {
-            "config-provider": "Primo\\Container\\ConfigProvider"
+            "config-provider": "Primo\\ConfigProvider"
         }
     },
     "scripts": {
@@ -59,5 +59,10 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always"
+    },
+    "suggest": {
+        "netglue/prismic-cli": "for building your custom content model definitions for the Prismic.io API",
+        "netglue/laminas-symfony-console": "for bootstrapping and configuring Symfony Console commands",
+        "laminas/laminas-cli": "for bootstrapping and configuring Symfony Console commands"
     }
 }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,6 +6,7 @@ namespace Primo;
 use Mezzio;
 use Primo\Content\Document;
 use Prismic;
+use Psr;
 
 final class ConfigProvider
 {
@@ -68,6 +69,8 @@ final class ConfigProvider
                 LinkResolver::class => Container\LinkResolverFactory::class,
             ],
             'aliases' => [
+                // Aliases our marker interface to the regular ClientInterface
+                Http\PrismicHttpClient::class => Psr\Http\Client\ClientInterface::class,
                 Prismic\ResultSet\ResultSetFactory::class => Prismic\ResultSet\StandardResultSetFactory::class,
                 // To Opt-In to Hydrating Result Sets, alias the Prismic ResultSetFactory to the Hydrating Result Set FQCN
                 //Prismic\ResultSet\ResultSetFactory::class => ResultSet\HydratingResultSetFactory::class,

--- a/src/Container/ApiFactory.php
+++ b/src/Container/ApiFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Primo\Container;
 
 use Primo\Exception\ConfigurationError;
+use Primo\Http\PrismicHttpClient;
 use Prismic\Api;
 use Prismic\ResultSet\ResultSetFactory;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 
@@ -27,7 +27,7 @@ final class ApiFactory
         return Api::get(
             $apiUrl,
             $config['prismic']['token'] ?? null,
-            $container->has(ClientInterface::class) ? $container->get(ClientInterface::class) : null,
+            $container->has(PrismicHttpClient::class) ? $container->get(PrismicHttpClient::class) : null,
             $container->has(RequestFactoryInterface::class) ? $container->get(RequestFactoryInterface::class) : null,
             $container->has(UriFactoryInterface::class) ? $container->get(UriFactoryInterface::class) : null,
             $container->has(ResultSetFactory::class) ? $container->get(ResultSetFactory::class) : null

--- a/src/Http/PrismicHttpClient.php
+++ b/src/Http/PrismicHttpClient.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Primo\Http;
+
+use Psr\Http\Client\ClientInterface;
+
+interface PrismicHttpClient extends ClientInterface
+{
+}


### PR DESCRIPTION
- Correct the config provider class name in composer.json
- Add some suggests to composer.json
- Create marker interface aliased to the std PSR http client in the container
- Change the ApiClient factory to retrieve the specific http client from the container