### PR TITLE
Fix HTTP Client alias so that it's a service with a factory meaning it can then be delegated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.2.1 - 2020-06-10
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#3](https://github.com/netglue/primo/pull/3) Fixes delegation of the Prismic specific http client by creating a factory for the client that can actually be delegated by consumers. Aliases don't trigger delegation in Laminas Service Manager which is a pain in the ass and something that is very likely we'll want to do.
+
 ## 0.2.0 - 2020-06-10
 
 ### Added

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,7 +6,6 @@ namespace Primo;
 use Mezzio;
 use Primo\Content\Document;
 use Prismic;
-use Psr;
 
 final class ConfigProvider
 {
@@ -54,6 +53,7 @@ final class ConfigProvider
     {
         return [
             'factories' => [
+                Http\PrismicHttpClient::class => Http\PrismicHttpClientFactory::class,
                 Middleware\DocumentResolver::class => Middleware\Container\DocumentResolverFactory::class,
                 Middleware\InjectRequestCookies::class => Middleware\Container\InjectRequestCookiesFactory::class,
                 Middleware\PreviewHandler::class => Middleware\Container\PreviewHandlerFactory::class,
@@ -69,8 +69,6 @@ final class ConfigProvider
                 LinkResolver::class => Container\LinkResolverFactory::class,
             ],
             'aliases' => [
-                // Aliases our marker interface to the regular ClientInterface
-                Http\PrismicHttpClient::class => Psr\Http\Client\ClientInterface::class,
                 Prismic\ResultSet\ResultSetFactory::class => Prismic\ResultSet\StandardResultSetFactory::class,
                 // To Opt-In to Hydrating Result Sets, alias the Prismic ResultSetFactory to the Hydrating Result Set FQCN
                 //Prismic\ResultSet\ResultSetFactory::class => ResultSet\HydratingResultSetFactory::class,

--- a/src/Http/PrismicHttpClientFactory.php
+++ b/src/Http/PrismicHttpClientFactory.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Primo\Http;
+
+use Http\Discovery\Psr18ClientDiscovery;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Client\ClientInterface;
+
+class PrismicHttpClientFactory
+{
+    public function __invoke(ContainerInterface $container) : ClientInterface
+    {
+        if ($container->has(ClientInterface::class)) {
+            return $container->get(ClientInterface::class);
+        }
+
+        return Psr18ClientDiscovery::find();
+    }
+}

--- a/test/Unit/Http/PrismicHttpClientFactoryTest.php
+++ b/test/Unit/Http/PrismicHttpClientFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace PrimoTest\Unit\Http;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Primo\Http\PrismicHttpClientFactory;
+use PrimoTest\Unit\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Client\ClientInterface;
+
+class PrismicHttpClientFactoryTest extends TestCase
+{
+    /** @var MockObject|ClientInterface */
+    private $container;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->container = $this->createMock(ContainerInterface::class);
+    }
+
+    private function clientInContainer(bool $value) : void
+    {
+        $this->container->expects($this->once())
+            ->method('has')
+            ->with(ClientInterface::class)
+            ->willReturn($value);
+    }
+
+    public function testThatClientInContainerWillBeReturnedWhenAvailable() : void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $this->clientInContainer(true);
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with(ClientInterface::class)
+            ->willReturn($client);
+
+        $factory = new PrismicHttpClientFactory();
+        $this->assertSame($client, $factory($this->container));
+    }
+
+    public function testThatClientDiscoveryWillBeUsedWhenNoClientIsInTheContainer() : void
+    {
+        $this->clientInContainer(false);
+        $this->container->expects($this->never())->method('get');
+        $factory = new PrismicHttpClientFactory();
+        $factory($this->container);
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
Aliases are not delegated in Laminas Service Manager