### PR TITLE
Don't set Last-Modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.5.0 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Changed the `DocumentResolver` middleware so that it does not set a `Last-Modified` header in the response after successfully resolving the requested document. It's not the responsibility of the resolver to do this, and, it's incorrect to assume that *nothing* has changed since the document was last published.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.4.0 - 2020-06-22
 
 ### Added

--- a/src/Middleware/DocumentResolver.php
+++ b/src/Middleware/DocumentResolver.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Primo\Middleware;
 
-use DateTimeInterface;
 use Mezzio\Router\RouteResult;
 use Primo\Exception\RequestError;
 use Primo\Router\DocumentResolver as Resolver;

--- a/src/Middleware/DocumentResolver.php
+++ b/src/Middleware/DocumentResolver.php
@@ -37,11 +37,6 @@ final class DocumentResolver implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $response = $handler->handle($request->withAttribute(Document::class, $document));
-
-        return $response->withHeader(
-            'Last-Modified',
-            $document->lastPublished()->format(DateTimeInterface::RFC7231)
-        );
+        return $handler->handle($request->withAttribute(Document::class, $document));
     }
 }

--- a/test/Unit/Middleware/DocumentResolverTest.php
+++ b/test/Unit/Middleware/DocumentResolverTest.php
@@ -87,12 +87,4 @@ class DocumentResolverTest extends TestCase
         $subject->process($request, $this->handler);
         $this->assertNull($this->handler->lastRequest->getAttribute(Document::class));
     }
-
-    /** @depends testThatGivenADocumentCanBeResolvedTheDocumentIsInjectedToRequestAttributes */
-    public function testThatTheResponseHasALastModifiedHeaderWhenADocumentCanBeResolved(ResponseInterface $response) : void
-    {
-        $date = DateTimeImmutable::createFromFormat('!Y-m-d', '2020-01-01', new DateTimeZone('UTC'));
-        $expectedDate = $date->format(DateTimeImmutable::RFC7231);
-        self::assertMessageHasHeader($response, 'Last-Modified', $this->equalTo($expectedDate));
-    }
 }


### PR DESCRIPTION
Changed the `DocumentResolver` middleware so that it does not set a `Last-Modified` header in the response after successfully resolving the requested document. It's not the responsibility of the resolver to do this, and, it's incorrect to assume that *nothing* has changed since the document was last published.