### PR TITLE
Fix #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.5.3 - 2021-03-29
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#15](https://github.com/netglue/primo/pull/15) fixes [#14](https://github.com/netglue/primo/issues/14).
+  When a route provides a document type _and_ an identifier, use that identifier to narrow down the result set to
+  a single document.
+
 ## 0.5.2 - 2021-03-25
 
 ### Added

--- a/src/Router/DocumentResolver.php
+++ b/src/Router/DocumentResolver.php
@@ -63,6 +63,7 @@ class DocumentResolver
         $params = $routeResult->getMatchedParams();
         $type = $params[$this->routeParams->type()] ?? null;
         $uid = $params[$this->routeParams->uid()]  ?? null;
+        $id = $params[$this->routeParams->id()] ?? null;
         $tags = $params[$this->routeParams->tag()] ?? null;
 
         // At least one of these must be present to attempt a match
@@ -82,6 +83,10 @@ class DocumentResolver
 
         if ($uid) {
             $predicates[] = Predicate::at(sprintf('my.%s.uid', $type), $uid);
+        }
+
+        if ($id) {
+            $predicates[] = Predicate::at('document.id', $id);
         }
 
         if (! empty($tags)) {

--- a/test/Unit/Router/DocumentResolverTest.php
+++ b/test/Unit/Router/DocumentResolverTest.php
@@ -220,7 +220,7 @@ class DocumentResolverTest extends TestCase
         $this->resolver->resolve($result);
     }
 
-    public function testThatWhenTheTypeAndIdentifierArePresentInRoutingParametersTheIsWillBeUsedToResolveADocument() : void
+    public function testThatWhenTheTypeAndIdentifierArePresentInRoutingParametersTheIsWillBeUsedToResolveADocument(): void
     {
         $document = $this->createMock(Document::class);
         $query = $this->createMock(Query::class);
@@ -236,13 +236,15 @@ class DocumentResolverTest extends TestCase
 
         $query->expects(self::once())
             ->method('query')
-            ->with(self::callback(function ($arg) {
+            ->with(self::callback(static function ($arg): bool {
                 $expect = (string) Predicate::at('document.type', 'type');
                 self::assertEquals($expect, (string) $arg);
+
                 return true;
-            }), self::callback(function ($arg) {
+            }), self::callback(static function ($arg): bool {
                 $expect = (string) Predicate::at('document.id', 'my-id');
                 self::assertEquals($expect, (string) $arg);
+
                 return true;
             }))
             ->willReturnSelf();


### PR DESCRIPTION
Fix #14 - When a type is given in a route without a UID, we should check to see if there is an ID parameter to narrow down the results to a single document