### PR TITLE
Add route names for webhook and preview routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.6.0 - TBD
+
+### Added
+
+- [#31](https://github.com/netglue/primo/pull/31) Adds a route name for both the preview and webhook routes. The routes are opt-in anyway, but you would typically execute `(new RouteProvider())($app, $container);` in your `routes.php` configuration file to benefit from these features. Adding the route name enables you to identify these routes and target them more easily. Both route names are identified with public constants that you can get from the RouteProvider with:
+    - `\Primo\RouteProvider::PREVIEW_ROUTE_NAME`
+    - `\Primo\RouteProvider::WEBHOOK_ROUTE_NAME`
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.5.4 - 2021-07-05
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,8 @@
     "require-dev": {
         "doctrine/coding-standard": "^9.0.0",
         "helmich/phpunit-psr7-assert": "^4.1",
+        "laminas/laminas-config-aggregator": "^1.5",
+        "laminas/laminas-servicemanager": "^3.6",
         "mezzio/mezzio-fastroute": "^3.0",
         "php-http/curl-client": "^2.1",
         "php-http/mock-client": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "PrimoTest\\Unit\\": "test/Unit"
+            "PrimoTest\\Unit\\": "test/Unit",
+            "PrimoTest\\Integration\\": "test/Integration"
         }
     },
     "require": {
@@ -36,7 +37,7 @@
         "mezzio/mezzio-template": "^2.0",
         "netglue/prismic-client": ">= 0.5 < 1.0",
         "psr/cache": "^1.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98fe66a940355972845c37bf6187abb7",
+    "content-hash": "c38ca7b677b9d8fa39ecc5b5a5ca3c7d",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2283,6 +2283,85 @@
     ],
     "packages-dev": [
         {
+            "name": "brick/varexporter",
+            "version": "0.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "05241f28dfcba2b51b11e2d750e296316ebbe518"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/05241f28dfcba2b51b11e2d750e296316ebbe518",
+                "reference": "05241f28dfcba2b51b11e2d750e296316ebbe518",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "4.4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.3.5"
+            },
+            "time": "2021-02-10T13:53:07+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "support": {
+                "issues": "https://github.com/container-interop/container-interop/issues",
+                "source": "https://github.com/container-interop/container-interop/tree/master"
+            },
+            "abandoned": "psr/container",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",
             "source": {
@@ -2662,6 +2741,163 @@
                 "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
             },
             "time": "2020-05-27T16:41:55+00:00"
+        },
+        {
+            "name": "laminas/laminas-config-aggregator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-config-aggregator.git",
+                "reference": "c5908c265ada01c8952baf84f102a073de30947f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-config-aggregator/zipball/c5908c265ada01c8952baf84f102a073de30947f",
+                "reference": "c5908c265ada01c8952baf84f102a073de30947f",
+                "shasum": ""
+            },
+            "require": {
+                "brick/varexporter": "^0.3.2",
+                "laminas/laminas-stdlib": "^2.7.7 || ^3.1.0",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ~8.0.0",
+                "webimpress/safe-writer": "^1.0.2 || ^2.0.1"
+            },
+            "replace": {
+                "zendframework/zend-config-aggregator": "^1.2.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6 || ^3.0",
+                "laminas/laminas-servicemanager": "^2.7.7 || ^3.1.1",
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "vimeo/psalm": "^4.6"
+            },
+            "suggest": {
+                "laminas/laminas-config": "Allows loading configuration from XML, INI, YAML, and JSON files",
+                "laminas/laminas-config-aggregator-modulemanager": "Allows loading configuration from laminas-mvc Module classes",
+                "laminas/laminas-config-aggregator-parameters": "Allows usage of templated parameters within your configuration"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ConfigAggregator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Lightweight library for collecting and merging configuration from different sources",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "config-aggregator",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-config-aggregator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-config-aggregator/issues",
+                "rss": "https://github.com/laminas/laminas-config-aggregator/releases.atom",
+                "source": "https://github.com/laminas/laminas-config-aggregator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-03-16T14:31:55+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ~8.0.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "zendframework/zend-servicemanager": "^3.4.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.0",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-container-config-test": "^0.3",
+                "laminas/laminas-dependency-plugin": "^2.1",
+                "mikey179/vfsstream": "^1.6.8",
+                "ocramius/proxy-manager": "^2.2.3",
+                "phpbench/phpbench": "^1.0.0-alpha3",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.4"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-02-03T08:44:41+00:00"
         },
         {
             "name": "mezzio/mezzio-fastroute",
@@ -5430,6 +5666,65 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webimpress/safe-writer",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/safe-writer.git",
+                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/safe-writer/zipball/9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
+                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4",
+                "vimeo/psalm": "^4.7",
+                "webimpress/coding-standard": "^1.2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-1.0": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webimpress\\SafeWriter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Tool to write files safely, to avoid race conditions",
+            "keywords": [
+                "concurrent write",
+                "file writer",
+                "race condition",
+                "safe writer",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/safe-writer/issues",
+                "source": "https://github.com/webimpress/safe-writer/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-19T16:34:45+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d87cdfb5c54a47ab85ef2dfe42c31e5",
+    "content-hash": "98fe66a940355972845c37bf6187abb7",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -3390,28 +3390,27 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e352d065af1ae9b41c12d1dfd309e90f7b1f55c9"
+                "reference": "ea0b17460ec38e20d7eb64e7ec49b5d44af5d28c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e352d065af1ae9b41c12d1dfd309e90f7b1f55c9",
-                "reference": "e352d065af1ae9b41c12d1dfd309e90f7b1f55c9",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/ea0b17460ec38e20d7eb64e7ec49b5d44af5d28c",
+                "reference": "ea0b17460ec38e20d7eb64e7ec49b5d44af5d28c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phing/phing": "^2.16.3",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.60",
+                "phpstan/phpstan": "^0.12.87",
                 "phpstan/phpstan-strict-rules": "^0.12.5",
-                "phpunit/phpunit": "^7.5.20",
+                "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -3434,9 +3433,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.5"
             },
-            "time": "2021-04-03T14:46:19+00:00"
+            "time": "2021-06-11T13:24:46+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3865,12 +3864,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "1a08d0c7ab47e57fad0d254951a615f07445e91f"
+                "reference": "fc5e5d772af47d035df8178172391259b6e30566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1a08d0c7ab47e57fad0d254951a615f07445e91f",
-                "reference": "1a08d0c7ab47e57fad0d254951a615f07445e91f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/fc5e5d772af47d035df8178172391259b6e30566",
+                "reference": "fc5e5d772af47d035df8178172391259b6e30566",
                 "shasum": ""
             },
             "conflict": {
@@ -3928,6 +3927,7 @@
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
                 "ezsystems/demobundle": ">=5.4,<5.4.6.1",
                 "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
@@ -4042,7 +4042,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
-                "pimcore/pimcore": "<6.8.8",
+                "pimcore/pimcore": "<10.0.7",
                 "pocketmine/pocketmine-mp": "<3.15.4",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -4233,7 +4233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-02T20:02:51+00:00"
+            "time": "2021-07-13T18:03:10+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5201,32 +5201,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.9",
+            "version": "7.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "d59652e000bcde019459dcba677de030867d0232"
+                "reference": "5716052725863953ddc2f8a7e934c09cb64bdf73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/d59652e000bcde019459dcba677de030867d0232",
-                "reference": "d59652e000bcde019459dcba677de030867d0232",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/5716052725863953ddc2f8a7e934c09cb64bdf73",
+                "reference": "5716052725863953ddc2f8a7e934c09cb64bdf73",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "0.5.1 - 0.5.4",
+                "phpstan/phpdoc-parser": "0.5.1 - 0.5.5",
                 "squizlabs/php_codesniffer": "^3.6.0"
             },
             "require-dev": {
                 "phing/phing": "2.16.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.0",
-                "phpstan/phpstan": "0.12.88",
+                "phpstan/phpstan": "0.12.91",
                 "phpstan/phpstan-deprecation-rules": "0.12.6",
-                "phpstan/phpstan-phpunit": "0.12.19",
-                "phpstan/phpstan-strict-rules": "0.12.9",
-                "phpunit/phpunit": "7.5.20|8.5.5|9.5.5"
+                "phpstan/phpstan-phpunit": "0.12.20",
+                "phpstan/phpstan-strict-rules": "0.12.10",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.6"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5246,7 +5246,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.9"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.12"
             },
             "funding": [
                 {
@@ -5258,7 +5258,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-07T10:08:42+00:00"
+            "time": "2021-07-13T17:47:03+00:00"
         },
         {
             "name": "softcreatr/jsonpath",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,5 +12,8 @@
         <testsuite name="Unit Tests">
             <directory>./test/Unit</directory>
         </testsuite>
+        <testsuite name="Integration Tests">
+            <directory>./test/Integration</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/RouteProvider.php
+++ b/src/RouteProvider.php
@@ -12,6 +12,9 @@ use Psr\Container\ContainerInterface;
 
 final class RouteProvider
 {
+    public const PREVIEW_ROUTE_NAME = 'prismic-preview-route';
+    public const WEBHOOK_ROUTE_NAME = 'prismic-webhook-route';
+
     public function __invoke(Application $application, ContainerInterface $container): void
     {
         $this->configurePreviews($container, $application);
@@ -25,7 +28,7 @@ final class RouteProvider
         $app->get($previewUrl, [
             PreviewHandler::class,
             ExpiredPreviewHandler::class,
-        ]);
+        ], self::PREVIEW_ROUTE_NAME);
     }
 
     private function configureWebhooks(ContainerInterface $container, Application $app): void
@@ -38,6 +41,6 @@ final class RouteProvider
         }
 
         $url = $options['url'] ?? ConfigProvider::DEFAULT_WEBHOOK_URL;
-        $app->post($url, WebhookHandler::class);
+        $app->post($url, WebhookHandler::class, self::WEBHOOK_ROUTE_NAME);
     }
 }

--- a/test/Integration/IntegrationTestCase.php
+++ b/test/Integration/IntegrationTestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrimoTest\Integration;
+
+use Laminas\ConfigAggregator\ConfigAggregator;
+use Laminas\ServiceManager\ServiceManager;
+use Mezzio;
+use Laminas;
+use PHPUnit\Framework\TestCase;
+use Primo\ConfigProvider;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    /**
+     * Returns application config as it would likely appear in a Mezzio Application
+     *
+     * @return array<array-key, mixed>
+     */
+    protected function getApplicationConfig(): array
+    {
+        $aggregator = new ConfigAggregator([
+            Mezzio\ConfigProvider::class,
+            Mezzio\Helper\ConfigProvider::class,
+            Mezzio\Router\ConfigProvider::class,
+            Mezzio\Router\FastRouteRouter\ConfigProvider::class,
+            Laminas\Diactoros\ConfigProvider::class,
+            ConfigProvider::class,
+        ]);
+
+        return $aggregator->getMergedConfig();
+    }
+
+    /**
+     * Returns a fresh container configured with application config as you'd expect for a Mezzio application
+     *
+     * Pass in custom application configuration if required.
+     *
+     * @param array<array-key, mixed>|null $withCustomConfiguration
+     */
+    protected function getContainer(?array $withCustomConfiguration = null): ContainerInterface
+    {
+        $config = $withCustomConfiguration ?: $this->getApplicationConfig();
+        assert(isset($config['dependencies']));
+        $dependencies = $config['dependencies'];
+        $dependencies['services']['config'] = $config;
+
+        return new ServiceManager($dependencies);
+    }
+
+    protected function getApplication(): Mezzio\Application
+    {
+        return $this->getContainer()->get(Mezzio\Application::class);
+    }
+}

--- a/test/Integration/IntegrationTestCase.php
+++ b/test/Integration/IntegrationTestCase.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PrimoTest\Integration;
 
+use Laminas;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ServiceManager\ServiceManager;
 use Mezzio;
-use Laminas;
 use PHPUnit\Framework\TestCase;
 use Primo\ConfigProvider;
 use Psr\Container\ContainerInterface;

--- a/test/Integration/RouteProviderTest.php
+++ b/test/Integration/RouteProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrimoTest\Integration;
+
+use Mezzio\Application;
+use Mezzio\Router\Route;
+use Primo\RouteProvider;
+
+use function array_map;
+use function sprintf;
+
+class RouteProviderTest extends IntegrationTestCase
+{
+    public function testThatTheApplicationDoesNotHaveTheWebhookRouteByDefault(): void
+    {
+        $application = $this->getApplication();
+        self::assertRouteNameNotFound(RouteProvider::WEBHOOK_ROUTE_NAME, $application);
+    }
+
+    public function testThatTheWebhookRouteWillNotBeFoundWhenTheRouteProviderIsInvokedWithTheDefaultConfig(): void
+    {
+        $container = $this->getContainer();
+        $application = $container->get(Application::class);
+        (new RouteProvider())($application, $container);
+        self::assertRouteNameNotFound(RouteProvider::WEBHOOK_ROUTE_NAME, $application);
+    }
+
+    public function testThatTheWebhookRouteWillBeAvailableWhenWebhooksHaveBeenEnabled(): void
+    {
+        $config = $this->getApplicationConfig();
+        $config['primo']['webhook']['enabled'] = true;
+        $container = $this->getContainer($config);
+        $application = $container->get(Application::class);
+        (new RouteProvider())($application, $container);
+        self::assertRouteNameFound(RouteProvider::WEBHOOK_ROUTE_NAME, $application);
+    }
+
+    public function testThatThePreviewRouteWillNotBeConfiguredByDefault(): void
+    {
+        $application = $this->getApplication();
+        self::assertRouteNameNotFound(RouteProvider::PREVIEW_ROUTE_NAME, $application);
+    }
+
+    public function testThatThePreviewRouteWillBeConfiguredWhenTheRouteProviderIsInvokedWithTheDefaultConfig(): void
+    {
+        $container = $this->getContainer();
+        $application = $container->get(Application::class);
+        (new RouteProvider())($application, $container);
+        self::assertRouteNameFound(RouteProvider::PREVIEW_ROUTE_NAME, $application);
+    }
+
+    public static function assertRouteNameNotFound(string $routeName, Application $application): void
+    {
+        $names = array_map(static function (Route $route): string {
+            return $route->getName();
+        }, $application->getRoutes());
+
+        self::assertNotContains($routeName, $names, sprintf(
+            'The route name "%s" should not be present in the configured routes but it was found',
+            $routeName
+        ));
+    }
+
+    public static function assertRouteNameFound(string $routeName, Application $application): void
+    {
+        $names = array_map(static function (Route $route): string {
+            return $route->getName();
+        }, $application->getRoutes());
+
+        self::assertContains($routeName, $names, sprintf(
+            'The route name "%s" was not present in the configured routes',
+            $routeName
+        ));
+    }
+}


### PR DESCRIPTION
This pull adds routes names to the opt-in routes provided by `RouteProvider`

The primary use case for this is so that you can target these routes more easily when, for example you're applying a CSRF to all post payloads on a website and need to exclude the webhook route from verifying the CSRF.