### PR TITLE
Deprecate Bookmarks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "helmich/phpunit-psr7-assert": "^4.3",
         "laminas/laminas-config-aggregator": "^1.6",
         "laminas/laminas-servicemanager": "^3.7",
+        "lctrs/psalm-psr-container-plugin": "^1.6",
         "mezzio/mezzio-fastroute": "^3.3.0",
         "php-http/curl-client": "^2.2",
         "php-http/mock-client": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bb93f536f4695d3ea5ea65907d1e954",
+    "content-hash": "103a6fb42d981bbf35ca36322fa70495",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -975,49 +975,54 @@
             "time": "2022-01-27T13:45:37+00:00"
         },
         {
-            "name": "php-http/curl-client",
-            "version": "2.2.1",
+            "name": "php-http/client-common",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-http/curl-client.git",
-                "reference": "2ed4245a817d859dd0c1d51c7078cdb343cf5233"
+                "url": "https://github.com/php-http/client-common.git",
+                "reference": "d135751167d57e27c74de674d6a30cef2dc8e054"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/curl-client/zipball/2ed4245a817d859dd0c1d51c7078cdb343cf5233",
-                "reference": "2ed4245a817d859dd0c1d51c7078cdb343cf5233",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/d135751167d57e27c74de674d6a30cef2dc8e054",
+                "reference": "d135751167d57e27c74de674d6a30cef2dc8e054",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
                 "php": "^7.1 || ^8.0",
-                "php-http/discovery": "^1.6",
                 "php-http/httplug": "^2.0",
-                "php-http/message": "^1.2",
+                "php-http/message": "^1.6",
+                "php-http/message-factory": "^1.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
-                "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0 || ^6.0"
-            },
-            "provide": {
-                "php-http/async-client-implementation": "1.0",
-                "php-http/client-implementation": "1.0",
-                "psr/http-client-implementation": "1.0"
+                "psr/http-message": "^1.0",
+                "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.17"
             },
             "require-dev": {
-                "guzzlehttp/psr7": "^1.0",
-                "laminas/laminas-diactoros": "^2.0",
-                "php-http/client-integration-tests": "^3.0",
-                "phpunit/phpunit": "^7.5 || ^9.4"
+                "doctrine/instantiator": "^1.1",
+                "guzzlehttp/psr7": "^1.4",
+                "nyholm/psr7": "^1.2",
+                "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
+                "phpspec/prophecy": "^1.10.2",
+                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.3"
+            },
+            "suggest": {
+                "ext-json": "To detect JSON responses with the ContentTypePlugin",
+                "ext-libxml": "To detect XML responses with the ContentTypePlugin",
+                "php-http/cache-plugin": "PSR-6 Cache plugin",
+                "php-http/logger-plugin": "PSR-3 Logger plugin",
+                "php-http/stopwatch-plugin": "Symfony Stopwatch plugin"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Http\\Client\\Curl\\": "src/"
+                    "Http\\Client\\Common\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1026,22 +1031,23 @@
             ],
             "authors": [
                 {
-                    "name": "Михаил Красильников",
-                    "email": "m.krasilnikov@yandex.ru"
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
                 }
             ],
-            "description": "PSR-18 and HTTPlug Async client with cURL",
-            "homepage": "http://php-http.org",
+            "description": "Common HTTP Client implementations and tools for HTTPlug",
+            "homepage": "http://httplug.io",
             "keywords": [
-                "curl",
+                "client",
+                "common",
                 "http",
-                "psr-18"
+                "httplug"
             ],
             "support": {
-                "issues": "https://github.com/php-http/curl-client/issues",
-                "source": "https://github.com/php-http/curl-client/tree/2.2.1"
+                "issues": "https://github.com/php-http/client-common/issues",
+                "source": "https://github.com/php-http/client-common/tree/2.5.0"
             },
-            "time": "2021-12-10T18:02:07+00:00"
+            "time": "2021-11-26T15:01:24+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -1300,6 +1306,74 @@
                 "source": "https://github.com/php-http/message-factory/tree/master"
             },
             "time": "2015-12-19T14:08:53+00:00"
+        },
+        {
+            "name": "php-http/mock-client",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/mock-client.git",
+                "reference": "a797c2a9122cccafcce14773b8a24d2808a9ab44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/mock-client/zipball/a797c2a9122cccafcce14773b8a24d2808a9ab44",
+                "reference": "a797c2a9122cccafcce14773b8a24d2808a9ab44",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/client-common": "^2.0",
+                "php-http/discovery": "^1.0",
+                "php-http/httplug": "^2.0",
+                "php-http/message-factory": "^1.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "symfony/polyfill-php80": "^1.17"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0",
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^5.1 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Mock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Mock HTTP client",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http",
+                "mock",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/mock-client/issues",
+                "source": "https://github.com/php-http/mock-client/tree/1.5.0"
+            },
+            "time": "2021-08-25T07:01:14+00:00"
         },
         {
             "name": "php-http/promise",
@@ -3493,6 +3567,84 @@
             "time": "2022-01-21T15:50:46+00:00"
         },
         {
+            "name": "lctrs/psalm-psr-container-plugin",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Lctrs/psalm-psr-container-plugin.git",
+                "reference": "799bd0af3ccf0f524e43527780e1b15ec9a60990"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Lctrs/psalm-psr-container-plugin/zipball/799bd0af3ccf0f524e43527780e1b15ec9a60990",
+                "reference": "799bd0af3ccf0f524e43527780e1b15ec9a60990",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "nikic/php-parser": "^4.13.2",
+                "php": "^7.3.0 || >=8.0.0 <8.2.0",
+                "psr/container": "^1.1.1",
+                "vimeo/psalm": "^4.16.1"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.1.27",
+                "codeception/module-asserts": "^1.3.1",
+                "codeception/module-cli": "^1.1.1",
+                "codeception/module-filesystem": "^1.0.3",
+                "doctrine/coding-standard": "^9.0.0",
+                "ergebnis/composer-normalize": "^2.20.0",
+                "ergebnis/license": "^1.1.0",
+                "phpstan/extension-installer": "^1.1.0",
+                "phpstan/phpstan": "^1.3.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.11",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "symfony/yaml": "^5.4.0",
+                "weirdan/codeception-psalm-module": "^0.13.1"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Lctrs\\PsalmPsrContainerPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lctrs\\PsalmPsrContainerPlugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Parmentier",
+                    "email": "jerome@prmntr.me"
+                }
+            ],
+            "description": "Let Psalm understand better psr11 containers",
+            "homepage": "https://github.com/Lctrs/psalm-psr-container-plugin",
+            "keywords": [
+                "code",
+                "container",
+                "inspection",
+                "php",
+                "psalm",
+                "psalm-plugin",
+                "psr",
+                "psr11"
+            ],
+            "support": {
+                "issues": "https://github.com/Lctrs/psalm-psr-container-plugin/issues",
+                "source": "https://github.com/Lctrs/psalm-psr-container-plugin"
+            },
+            "time": "2021-12-29T20:10:48+00:00"
+        },
+        {
             "name": "mezzio/mezzio-fastroute",
             "version": "3.4.0",
             "source": {
@@ -3951,104 +4103,28 @@
             "time": "2021-02-23T14:00:09+00:00"
         },
         {
-            "name": "php-http/client-common",
-            "version": "2.5.0",
+            "name": "php-http/curl-client",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-http/client-common.git",
-                "reference": "d135751167d57e27c74de674d6a30cef2dc8e054"
+                "url": "https://github.com/php-http/curl-client.git",
+                "reference": "2ed4245a817d859dd0c1d51c7078cdb343cf5233"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/client-common/zipball/d135751167d57e27c74de674d6a30cef2dc8e054",
-                "reference": "d135751167d57e27c74de674d6a30cef2dc8e054",
+                "url": "https://api.github.com/repos/php-http/curl-client/zipball/2ed4245a817d859dd0c1d51c7078cdb343cf5233",
+                "reference": "2ed4245a817d859dd0c1d51c7078cdb343cf5233",
                 "shasum": ""
             },
             "require": {
+                "ext-curl": "*",
                 "php": "^7.1 || ^8.0",
+                "php-http/discovery": "^1.6",
                 "php-http/httplug": "^2.0",
-                "php-http/message": "^1.6",
-                "php-http/message-factory": "^1.0",
+                "php-http/message": "^1.2",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
-                "symfony/options-resolver": "~4.0.15 || ~4.1.9 || ^4.2.1 || ^5.0 || ^6.0",
-                "symfony/polyfill-php80": "^1.17"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "^1.1",
-                "guzzlehttp/psr7": "^1.4",
-                "nyholm/psr7": "^1.2",
-                "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
-                "phpspec/prophecy": "^1.10.2",
-                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.3"
-            },
-            "suggest": {
-                "ext-json": "To detect JSON responses with the ContentTypePlugin",
-                "ext-libxml": "To detect XML responses with the ContentTypePlugin",
-                "php-http/cache-plugin": "PSR-6 Cache plugin",
-                "php-http/logger-plugin": "PSR-3 Logger plugin",
-                "php-http/stopwatch-plugin": "Symfony Stopwatch plugin"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Client\\Common\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Common HTTP Client implementations and tools for HTTPlug",
-            "homepage": "http://httplug.io",
-            "keywords": [
-                "client",
-                "common",
-                "http",
-                "httplug"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/client-common/issues",
-                "source": "https://github.com/php-http/client-common/tree/2.5.0"
-            },
-            "time": "2021-11-26T15:01:24+00:00"
-        },
-        {
-            "name": "php-http/mock-client",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/mock-client.git",
-                "reference": "a797c2a9122cccafcce14773b8a24d2808a9ab44"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/mock-client/zipball/a797c2a9122cccafcce14773b8a24d2808a9ab44",
-                "reference": "a797c2a9122cccafcce14773b8a24d2808a9ab44",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "php-http/client-common": "^2.0",
-                "php-http/discovery": "^1.0",
-                "php-http/httplug": "^2.0",
-                "php-http/message-factory": "^1.0",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
-                "symfony/polyfill-php80": "^1.17"
+                "symfony/options-resolver": "^3.4 || ^4.0 || ^5.0 || ^6.0"
             },
             "provide": {
                 "php-http/async-client-implementation": "1.0",
@@ -4056,17 +4132,20 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^5.1 || ^6.0"
+                "guzzlehttp/psr7": "^1.0",
+                "laminas/laminas-diactoros": "^2.0",
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^7.5 || ^9.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Http\\Mock\\": "src/"
+                    "Http\\Client\\Curl\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4075,23 +4154,22 @@
             ],
             "authors": [
                 {
-                    "name": "David de Boer",
-                    "email": "david@ddeboer.nl"
+                    "name": "Михаил Красильников",
+                    "email": "m.krasilnikov@yandex.ru"
                 }
             ],
-            "description": "Mock HTTP client",
-            "homepage": "http://httplug.io",
+            "description": "PSR-18 and HTTPlug Async client with cURL",
+            "homepage": "http://php-http.org",
             "keywords": [
-                "client",
+                "curl",
                 "http",
-                "mock",
-                "psr7"
+                "psr-18"
             ],
             "support": {
-                "issues": "https://github.com/php-http/mock-client/issues",
-                "source": "https://github.com/php-http/mock-client/tree/1.5.0"
+                "issues": "https://github.com/php-http/curl-client/issues",
+                "source": "https://github.com/php-http/curl-client/tree/2.2.1"
             },
-            "time": "2021-08-25T07:01:14+00:00"
+            "time": "2021-12-10T18:02:07+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,36 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
-  <file src="src/Container/ApiFactory.php">
-    <MixedArgument occurrences="7">
-      <code>$apiUrl</code>
-      <code>$config['prismic']['token'] ?? null</code>
-      <code>$container-&gt;has(PrismicApiCache::class) ? $container-&gt;get(PrismicApiCache::class) : null</code>
-      <code>$container-&gt;has(PrismicHttpClient::class) ? $container-&gt;get(PrismicHttpClient::class) : null</code>
-      <code>$container-&gt;has(RequestFactoryInterface::class) ? $container-&gt;get(RequestFactoryInterface::class) : null</code>
-      <code>$container-&gt;has(ResultSetFactory::class) ? $container-&gt;get(ResultSetFactory::class) : null</code>
-      <code>$container-&gt;has(UriFactoryInterface::class) ? $container-&gt;get(UriFactoryInterface::class) : null</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$config['prismic']</code>
-      <code>$config['prismic']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$apiUrl</code>
-      <code>$config</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Container/LinkResolverFactory.php">
-    <MixedArgument occurrences="4">
-      <code>$container-&gt;get(ApiClient::class)-&gt;data()-&gt;bookmarks()</code>
-      <code>$container-&gt;get(RouteMatcher::class)</code>
-      <code>$container-&gt;get(RouteParams::class)</code>
-      <code>$container-&gt;get(UrlHelper::class)</code>
-    </MixedArgument>
-    <MixedMethodCall occurrences="2">
-      <code>bookmarks</code>
-      <code>data</code>
-    </MixedMethodCall>
-  </file>
+<files psalm-version="4.19.0@a2ad69ae4f5ab1f7d225a8dc4e2ec2d9415ed599">
   <file src="src/Event/WebhookEvent.php">
     <FalsableReturnStatement occurrences="1">
       <code>DateTimeImmutable::createFromFormat('U', (string) $this-&gt;received, new DateTimeZone('UTC'))</code>
@@ -54,14 +23,6 @@
   <file src="src/Exception/RoutingError.php">
     <UnsafeInstantiation occurrences="2"/>
   </file>
-  <file src="src/Http/PrismicHttpClientFactory.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>ClientInterface</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$container-&gt;get(ClientInterface::class)</code>
-    </MixedReturnStatement>
-  </file>
   <file src="src/LinkResolver.php">
     <MixedArrayAccess occurrences="1">
       <code>$options['defaults'][$this-&gt;routeParams-&gt;reuseResultParams()]</code>
@@ -69,11 +30,6 @@
     <MixedAssignment occurrences="1">
       <code>$reuseResultParams</code>
     </MixedAssignment>
-  </file>
-  <file src="src/Middleware/Container/DocumentResolverFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(Resolver::class)</code>
-    </MixedArgument>
   </file>
   <file src="src/Middleware/Container/ExpiredPreviewHandlerFactory.php">
     <MixedArgument occurrences="1">
@@ -86,20 +42,8 @@
       <code>$config</code>
     </MixedAssignment>
   </file>
-  <file src="src/Middleware/Container/InjectRequestCookiesFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(ApiClient::class)</code>
-    </MixedArgument>
-  </file>
-  <file src="src/Middleware/Container/PreviewCacheHeadersFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(ApiClient::class)</code>
-    </MixedArgument>
-  </file>
   <file src="src/Middleware/Container/PreviewHandlerFactory.php">
-    <MixedArgument occurrences="3">
-      <code>$container-&gt;get(ApiClient::class)</code>
-      <code>$container-&gt;get(LinkResolver::class)</code>
+    <MixedArgument occurrences="1">
       <code>$defaultUrl</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
@@ -111,8 +55,7 @@
     </MixedAssignment>
   </file>
   <file src="src/Middleware/Container/PrismicTemplateFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$container-&gt;get(TemplateRendererInterface::class)</code>
+    <MixedArgument occurrences="1">
       <code>$templateAttribute</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
@@ -133,12 +76,6 @@
     <MixedAssignment occurrences="1">
       <code>$config</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>EventDispatcherInterface</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$container-&gt;get(EventDispatcherInterface::class)</code>
-    </MixedReturnStatement>
   </file>
   <file src="src/Middleware/InjectRequestCookies.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -157,11 +94,6 @@
     <MixedAssignment occurrences="1">
       <code>$template</code>
     </MixedAssignment>
-  </file>
-  <file src="src/ResultSet/Container/HydratingResultSetFactoryFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(TypeMap::class)</code>
-    </MixedArgument>
   </file>
   <file src="src/ResultSet/Container/TypeMapFactory.php">
     <MixedArgument occurrences="2">
@@ -226,18 +158,6 @@
       <code>$url</code>
     </MixedAssignment>
   </file>
-  <file src="src/Router/Container/DocumentResolverFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$container-&gt;get(ApiClient::class)</code>
-      <code>$container-&gt;get(RouteParams::class)</code>
-    </MixedArgument>
-  </file>
-  <file src="src/Router/Container/RouteMatcherFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$container-&gt;get(RouteCollector::class)</code>
-      <code>$container-&gt;get(RouteParams::class)</code>
-    </MixedArgument>
-  </file>
   <file src="src/Router/Container/RouteParamsFactory.php">
     <MixedArgument occurrences="1">
       <code>$options</code>
@@ -291,11 +211,6 @@
       <code>string[]</code>
     </MixedReturnTypeCoercion>
   </file>
-  <file src="src/Router/RouteParams.php">
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$name</code>
-    </MixedArgumentTypeCoercion>
-  </file>
   <file src="test/Integration/IntegrationTestCase.php">
     <MixedArgument occurrences="1">
       <code>$dependencies</code>
@@ -309,27 +224,11 @@
     <MixedAssignment occurrences="1">
       <code>$dependencies</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>Mezzio\Application</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;getContainer()-&gt;get(Mezzio\Application::class)</code>
-    </MixedReturnStatement>
   </file>
   <file src="test/Integration/RouteProviderTest.php">
-    <MixedArgument occurrences="3">
-      <code>$application</code>
-      <code>$application</code>
-      <code>$application</code>
-    </MixedArgument>
     <MixedArrayAssignment occurrences="1">
       <code>$config['primo']['webhook']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
-      <code>$application</code>
-      <code>$application</code>
-      <code>$application</code>
-    </MixedAssignment>
   </file>
   <file src="test/Unit/Container/StandardResultSetFactoryFactoryTest.php">
     <InternalMethod occurrences="1">
@@ -453,91 +352,5 @@
   </file>
   <file src="test/Unit/ResultSet/TypeMapTest.php">
     <InvalidArgument occurrences="3"/>
-    <UndefinedClass occurrences="1">
-      <code>UnknownClass</code>
-    </UndefinedClass>
-  </file>
-  <file src="test/Unit/Router/Container/RouteParamsFactoryTest.php">
-    <MixedMethodCall occurrences="11">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-    </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$this-&gt;container</code>
-      <code>$this-&gt;container</code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedMethod occurrences="4">
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </PossiblyUndefinedMethod>
-  </file>
-  <file src="test/Unit/Router/DocumentResolverTest.php">
-    <MissingClosureParamType occurrences="2">
-      <code>$arg</code>
-      <code>$arg</code>
-    </MissingClosureParamType>
-    <MixedMethodCall occurrences="21">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-    </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="8">
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </PossiblyUndefinedMethod>
-  </file>
-  <file src="test/Unit/Router/RouteMatcherTest.php">
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$name</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
-      <code>$defaults</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/Unit/Router/RouteParamsTest.php">
-    <InternalMethod occurrences="1">
-      <code>addToAssertionCount</code>
-    </InternalMethod>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$options</code>
-    </MixedArgumentTypeCoercion>
-    <MixedInferredReturnType occurrences="1">
-      <code>mixed[]</code>
-    </MixedInferredReturnType>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -35,5 +35,6 @@
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        <pluginClass class="Lctrs\PsalmPsrContainerPlugin\Plugin"/>
     </plugins>
 </psalm>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -12,7 +12,7 @@ final class ConfigProvider
     public const DEFAULT_PREVIEW_URL = '/preview';
     public const DEFAULT_WEBHOOK_URL = '/prismic-webhook';
 
-    /** @return mixed[] */
+    /** @return array<string, mixed[]> */
     public function __invoke(): array
     {
         return [
@@ -48,7 +48,7 @@ final class ConfigProvider
         ];
     }
 
-    /** @return mixed[] */
+    /** @return array{factories: array<class-string, class-string>, aliases: array<class-string, class-string>} */
     private function dependencies(): array
     {
         return [
@@ -78,7 +78,7 @@ final class ConfigProvider
         ];
     }
 
-    /** @return mixed[] */
+    /** @return array{params: array<string, string>} */
     private function routing(): array
     {
         return [

--- a/src/Container/ApiFactory.php
+++ b/src/Container/ApiFactory.php
@@ -13,22 +13,32 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 
+use function assert;
+use function is_array;
+use function is_string;
+
 final class ApiFactory
 {
     public function __invoke(ContainerInterface $container): Api
     {
         $config = $container->has('config') ? $container->get('config') : [];
-        $apiUrl = $config['prismic']['api'] ?? null;
-        if (empty($apiUrl)) {
+        assert(is_array($config));
+        $config = isset($config['prismic']) && is_array($config['prismic']) ? $config['prismic'] : [];
+
+        $apiUrl = $config['api'] ?? null;
+        if (empty($apiUrl) || ! is_string($apiUrl)) {
             throw new ConfigurationError(
                 'An api url cannot be determined. Your content repository url should be available in ' .
                 'configuration under [prismic][api] and should be a non-empty string.'
             );
         }
 
+        $accessToken = $config['token'] ?? null;
+        assert(is_string($accessToken) || $accessToken === null);
+
         return Api::get(
             $apiUrl,
-            $config['prismic']['token'] ?? null,
+            $accessToken,
             $container->has(PrismicHttpClient::class) ? $container->get(PrismicHttpClient::class) : null,
             $container->has(RequestFactoryInterface::class) ? $container->get(RequestFactoryInterface::class) : null,
             $container->has(UriFactoryInterface::class) ? $container->get(UriFactoryInterface::class) : null,

--- a/src/Container/LinkResolverFactory.php
+++ b/src/Container/LinkResolverFactory.php
@@ -13,6 +13,7 @@ use Psr\Container\ContainerInterface;
 
 final class LinkResolverFactory
 {
+    /** @psalm-suppress DeprecatedClass, DeprecatedMethod */
     public function __invoke(ContainerInterface $container): LinkResolver
     {
         return new LinkResolver(

--- a/src/LinkResolver.php
+++ b/src/LinkResolver.php
@@ -15,20 +15,28 @@ use Prismic\UrlLink;
 use Prismic\Value\Bookmark;
 
 /**
- * @psalm-suppress DeprecatedClass
+ * @psalm-suppress DeprecatedClass, DeprecatedMethod, DeprecatedProperty
  */
 final class LinkResolver implements PrismicLinkResolver
 {
     /** @var RouteParams */
     private $routeParams;
-    /** @var Bookmark[] */
+    /**
+     * @deprecated
+     *
+     * @var Bookmark[]
+     */
     private $bookmarks;
     /** @var RouteMatcher */
     private $routeMatcher;
     /** @var UrlHelper */
     private $urlHelper;
 
-    /** @param Bookmark[] $bookmarks */
+    /**
+     * @deprecated $bookmarks
+     *
+     * @param Bookmark[] $bookmarks
+     */
     public function __construct(RouteParams $routeParams, RouteMatcher $matcher, UrlHelper $urlHelper, iterable $bookmarks)
     {
         $this->routeParams = $routeParams;
@@ -86,6 +94,9 @@ final class LinkResolver implements PrismicLinkResolver
         ];
     }
 
+    /**
+     * @deprecated
+     */
     private function bookmarkNameByDocumentId(string $id): ?string
     {
         foreach ($this->bookmarks as $bookmark) {

--- a/src/Router/DocumentResolver.php
+++ b/src/Router/DocumentResolver.php
@@ -14,6 +14,9 @@ use function count;
 use function is_string;
 use function sprintf;
 
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
 class DocumentResolver
 {
     /** @var RouteParams */
@@ -47,7 +50,7 @@ class DocumentResolver
     }
 
     /**
-     * @psalm-suppress DeprecatedMethod
+     * @deprecated
      */
     private function resolveWithBookmark(RouteResult $routeResult): ?Document
     {

--- a/src/Router/RouteMatcher.php
+++ b/src/Router/RouteMatcher.php
@@ -16,6 +16,9 @@ use function is_array;
 use function is_string;
 use function uasort;
 
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
 final class RouteMatcher
 {
     /** @var RouteParams */
@@ -81,6 +84,7 @@ final class RouteMatcher
         return $this->routeMatchingId($id);
     }
 
+    /** @deprecated */
     public function getBookmarkedRoute(string $bookmark): ?Route
     {
         foreach ($this->routes() as $route) {

--- a/src/Router/RouteParams.php
+++ b/src/Router/RouteParams.php
@@ -10,6 +10,9 @@ use function implode;
 use function in_array;
 use function sprintf;
 
+/**
+ * @psalm-suppress DeprecatedProperty
+ */
 final class RouteParams
 {
     /** @var string */
@@ -18,7 +21,11 @@ final class RouteParams
     private $uid = 'document-uid';
     /** @var string */
     private $type = 'document-type';
-    /** @var string */
+    /**
+     * @deprecated
+     *
+     * @var string
+     */
     private $bookmark = 'document-bookmark';
     /** @var string */
     private $lang = 'document-lang';
@@ -33,10 +40,10 @@ final class RouteParams
     {
     }
 
-    /** @param string[] $options */
+    /** @param array<string, string> $options */
     public static function fromArray(array $options): self
     {
-        $params = new static();
+        $params = new self();
         foreach ($options as $name => $value) {
             $params->setParameter($name, $value);
         }
@@ -72,6 +79,7 @@ final class RouteParams
         return $this->type;
     }
 
+    /** @deprecated */
     public function bookmark(): string
     {
         return $this->bookmark;

--- a/test/Unit/Router/Container/RouteParamsFactoryTest.php
+++ b/test/Unit/Router/Container/RouteParamsFactoryTest.php
@@ -9,11 +9,14 @@ use Primo\Router\Container\RouteParamsFactory;
 use PrimoTest\Unit\TestCase;
 use Psr\Container\ContainerInterface;
 
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
 class RouteParamsFactoryTest extends TestCase
 {
     /** @var RouteParamsFactory */
     private $factory;
-    /** @var MockObject|ContainerInterface */
+    /** @var MockObject&ContainerInterface */
     private $container;
 
     protected function setUp(): void

--- a/test/Unit/Router/DocumentResolverTest.php
+++ b/test/Unit/Router/DocumentResolverTest.php
@@ -22,9 +22,12 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
 class DocumentResolverTest extends TestCase
 {
-    /** @var MockObject|ApiClient */
+    /** @var MockObject&ApiClient */
     private $api;
     /** @var DocumentResolver */
     private $resolver;

--- a/test/Unit/Router/RouteMatcherTest.php
+++ b/test/Unit/Router/RouteMatcherTest.php
@@ -17,6 +17,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
 class RouteMatcherTest extends TestCase
 {
     /** @var RouteParams */
@@ -169,8 +172,8 @@ class RouteMatcherTest extends TestCase
         self::assertSame($route, $matcher->getUidRoute('a', 'bar'));
     }
 
-    /** @return mixed[] */
-    public function routeMatchingProvider(): array
+    /** @return array<string, array<string, mixed>> */
+    private function routeMatchingProvider(): array
     {
         return [
             'bookmark' => [$this->params->bookmark() => 'mark'],

--- a/test/Unit/Router/RouteParamsTest.php
+++ b/test/Unit/Router/RouteParamsTest.php
@@ -9,6 +9,9 @@ use Primo\Router\RouteParams;
 use PrimoTest\Unit\TestCase;
 use TypeError;
 
+/**
+ * @psalm-suppress DeprecatedMethod
+ */
 class RouteParamsTest extends TestCase
 {
     public function testOptionsArray(): RouteParams
@@ -22,7 +25,7 @@ class RouteParamsTest extends TestCase
             'reuseResultParams' => 'reuse',
         ];
         $params = RouteParams::fromArray($options);
-        $this->addToAssertionCount(1);
+        self::assertTrue(true);
 
         return $params;
     }
@@ -63,8 +66,8 @@ class RouteParamsTest extends TestCase
         self::assertSame('reuse', $params->reuseResultParams());
     }
 
-    /** @return mixed[] */
-    public function typeErrorProvider(): iterable
+    /** @return array<string, array{0: array<array-key, mixed>}> */
+    public function typeErrorProvider(): array
     {
         return [
             'Non string option key' => [[0 => 'value']],
@@ -73,13 +76,14 @@ class RouteParamsTest extends TestCase
     }
 
     /**
-     * @param mixed[] $options
+     * @param array<array-key, mixed> $options
      *
      * @dataProvider typeErrorProvider
      */
     public function testOptionTypeError(array $options): void
     {
         $this->expectException(TypeError::class);
+        /** @psalm-suppress MixedArgumentTypeCoercion, PossiblyInvalidArgument */
         RouteParams::fromArray($options);
     }
 


### PR DESCRIPTION
- Deprecates RouteMatcher::getBookmarkedRoute()
- Deprecates RouteParams::bookmark()
- Deprecates internal bookmark related methods
- Suppress deprecation related psalm errors
- Drive-by psalm fixes and baseline reduction